### PR TITLE
fix: remove Open in VSCode/Cursor icon from status bar

### DIFF
--- a/apps/dashboard/src/components/layout/project-status-bar.tsx
+++ b/apps/dashboard/src/components/layout/project-status-bar.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useMemo } from 'react';
-import { GitBranch, ExternalLink, Loader2, RefreshCw, ArrowUp, ArrowDown, Radio } from 'lucide-react';
-import { type Project, projectsApi } from '../../api/client';
+import { useState, useCallback } from 'react';
+import { GitBranch, RefreshCw, ArrowUp, ArrowDown, Radio } from 'lucide-react';
+import { type Project } from '../../api/client';
 import { SandboxStatus } from './sandbox-status';
 import { BranchPicker } from './branch-picker';
 import { cn } from '../../lib/cn';
@@ -9,25 +9,6 @@ import { usePortsStore } from '../../stores/ports-store';
 import { useTerminalStore } from '../../stores/terminal-store';
 import type { ProjectInfo } from '../../hooks/use-project-info-socket';
 import type { GitActions } from '../../hooks/use-git-socket';
-
-interface ApexBridge {
-  isElectron: boolean;
-  platform: string;
-  openWindow: (urlPath: string) => void;
-  detectedIDEs?: { cursor: boolean; vscode: boolean };
-  openInIDE?: (params: {
-    ide: 'cursor' | 'vscode';
-    sshUser: string;
-    sshHost: string;
-    sshPort: number;
-    sandboxId: string;
-    remotePath: string;
-  }) => Promise<{ ok: boolean; error?: string }>;
-}
-
-function getApexBridge(): ApexBridge | null {
-  return (window as any).apex ?? null;
-}
 
 interface Props {
   project: Project;
@@ -39,7 +20,6 @@ interface Props {
 }
 
 export function ProjectStatusBar({ project, info, gitActions, onStop, onStart, onRestart }: Props) {
-  const [vscLoading, setVscLoading] = useState(false);
   const [branchPickerOpen, setBranchPickerOpen] = useState(false);
   const storeBranch = useGitStore((s) => s.branch);
   const ahead = useGitStore((s) => s.ahead);
@@ -51,48 +31,12 @@ export function ProjectStatusBar({ project, info, gitActions, onStop, onStart, o
   const showPortsTab = useTerminalStore((s) => s.showPortsTab);
 
   const branchLabel = storeBranch || info.gitBranch || project.gitRepo;
-  const sandboxReady = project.status === 'running' && !!project.sandboxId;
-
-  const apexBridge = useMemo(() => getApexBridge(), []);
-  const ides = apexBridge?.detectedIDEs;
-  const preferredIDE: 'cursor' | 'vscode' | null = ides?.cursor
-    ? 'cursor'
-    : ides?.vscode
-      ? 'vscode'
-      : null;
-  const nativeIDEAvailable = !!apexBridge?.isElectron && !!preferredIDE;
-
-  const ideLabel = preferredIDE === 'cursor' ? 'Cursor' : 'VS Code';
 
   const openPortsPanel = useCallback(() => {
     showPortsTab();
     openPanel();
     setActiveBottomTab('ports');
   }, [showPortsTab, openPanel, setActiveBottomTab]);
-
-  const openIDE = useCallback(async () => {
-    if (!sandboxReady) return;
-    setVscLoading(true);
-    try {
-      if (nativeIDEAvailable && apexBridge?.openInIDE) {
-        const sshAccess = await projectsApi.createSshAccess(project.id);
-        const result = await apexBridge.openInIDE({
-          ide: preferredIDE!,
-          ...sshAccess,
-        });
-        if (!result.ok) {
-          console.error('Failed to open IDE:', result.error);
-        }
-      } else {
-        const { url } = await projectsApi.getVscodeUrl(project.id);
-        window.open(url, '_blank', 'noopener');
-      }
-    } catch (err) {
-      console.error('Failed to open IDE:', err);
-    } finally {
-      setVscLoading(false);
-    }
-  }, [project.id, sandboxReady, nativeIDEAvailable, apexBridge, preferredIDE]);
 
   return (
     <div className="h-7 border-t border-panel-border bg-activity-bar flex items-center px-3 shrink-0 text-xs text-panel-text-muted select-none gap-4">
@@ -166,54 +110,10 @@ export function ProjectStatusBar({ project, info, gitActions, onStop, onStart, o
           onRestart={onRestart}
         />
 
-        {/* IDE button (Cursor / VS Code native or code-server fallback) */}
-        <button
-          onClick={openIDE}
-          disabled={!sandboxReady || vscLoading}
-          title={
-            !sandboxReady
-              ? 'Sandbox not ready'
-              : nativeIDEAvailable
-                ? `Open in ${ideLabel} (SSH)`
-                : 'Open VS Code in browser'
-          }
-          className={cn(
-            'flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium',
-            'border transition-colors',
-            sandboxReady
-              ? 'bg-blue-500/10 border-blue-500/30 text-blue-400 hover:bg-blue-500/20 hover:border-blue-500/50 cursor-pointer'
-              : 'border-transparent text-text-muted cursor-not-allowed opacity-50',
-          )}
-        >
-          {vscLoading ? (
-            <Loader2 className="w-3 h-3 animate-spin" />
-          ) : (
-            <VscodeIcon className="w-3 h-3" />
-          )}
-          <span>{nativeIDEAvailable ? ideLabel : 'VS Code'}</span>
-          {sandboxReady && !vscLoading && !nativeIDEAvailable && (
-            <ExternalLink className="w-2.5 h-2.5 opacity-60" />
-          )}
-        </button>
-
         <span className="text-[10px] text-panel-text-muted/50 select-none">
           v{__APP_VERSION__}
         </span>
       </div>
     </div>
-  );
-}
-
-/** Inline VS Code icon (simplified logo) */
-function VscodeIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M17.583 2.213a1.125 1.125 0 0 1 1.23.038l3.937 2.55A1.125 1.125 0 0 1 23.25 5.8v12.4a1.125 1.125 0 0 1-.5 1l-3.937 2.55a1.125 1.125 0 0 1-1.313-.075L7.125 12.75.963 17.85a.75.75 0 0 1-.963-.075l-.75-.75a.75.75 0 0 1 0-1.05L5.625 12 .25 8.025a.75.75 0 0 1 0-1.05l.75-.75a.75.75 0 0 1 .963-.075l6.162 5.1L17.583 2.213ZM18 7.65 12.375 12 18 16.35V7.65Z" />
-    </svg>
   );
 }


### PR DESCRIPTION
- Remove IDE button component and related functionality from ProjectStatusBar
- Clean up unused imports (ExternalLink, Loader2, useMemo, projectsApi)
- Remove ApexBridge interface and IDE detection logic
- Remove VscodeIcon component
- Preserve all other status bar functionality (git, ports, sandbox, version)

Fixes #6