### PR TITLE
Issue 11/preserve draft text when switching between threads

### DIFF
--- a/apps/dashboard/src/components/agent/prompt-input.tsx
+++ b/apps/dashboard/src/components/agent/prompt-input.tsx
@@ -11,6 +11,7 @@ import { FilePicker } from './file-picker';
 import { AgentDropdown, ModelDropdown } from './mode-model-dropdowns';
 import { useAgentSettingsStore } from '../../stores/agent-settings-store';
 import { useEditorStore, type CodeSelection } from '../../stores/editor-store';
+import { useThreadsStore } from '../../stores/tasks-store';
 import type { ImageSource, GitHubContextData } from '../../api/client';
 
 export interface ImageAttachment {
@@ -195,6 +196,9 @@ export const PromptInput = forwardRef<PromptInputHandle, Props>(
     const [empty, setEmpty] = useState(true);
     const [images, setImages] = useState<ImageAttachment[]>([]);
     const triggerRangeRef = useRef<Range | null>(null);
+    
+    // Access thread store for draft management
+    const { activeThreadId, composingNew, setThreadDraft, getThreadDraft, clearThreadDraft } = useThreadsStore();
 
     const showPicker = pickerMode !== null;
 
@@ -204,15 +208,43 @@ export const PromptInput = forwardRef<PromptInputHandle, Props>(
         if (!el) return;
         el.textContent = text;
         setEmpty(!text);
+        
+        // Update draft when text is programmatically filled
+        const threadKey = composingNew ? 'new-thread' : activeThreadId || '';
+        if (text.trim()) {
+          setThreadDraft(threadKey, text);
+        } else {
+          clearThreadDraft(threadKey);
+        }
+        
         setTimeout(() => el.focus(), 0);
       },
-    }));
+    }), [composingNew, activeThreadId, setThreadDraft, clearThreadDraft]);
 
     useEffect(() => {
       if (autoFocus && editorRef.current) {
         editorRef.current.focus();
       }
     }, [autoFocus]);
+
+    // Restore draft when component mounts or thread changes
+    useEffect(() => {
+      const el = editorRef.current;
+      if (!el) return;
+      
+      const threadKey = composingNew ? 'new-thread' : activeThreadId || '';
+      const savedDraft = getThreadDraft(threadKey);
+      
+      if (savedDraft) {
+        el.innerHTML = '';
+        el.textContent = savedDraft;
+        setEmpty(!savedDraft.trim());
+      } else if (!composingNew) {
+        // Clear editor if switching to a thread with no draft
+        el.innerHTML = '';
+        setEmpty(true);
+      }
+    }, [activeThreadId, composingNew, getThreadDraft]);
 
     useEffect(() => {
       const handleDocCopy = () => {
@@ -296,10 +328,16 @@ Instructions:
         agentType,
         images.length > 0 ? images : undefined,
       );
+      
+      // Clear the editor and draft on successful send
       el.innerHTML = '';
       setEmpty(true);
       setImages([]);
-    }, [onSend, disabled, images, githubContext]);
+      
+      // Clear the draft for the current thread
+      const threadKey = composingNew ? 'new-thread' : activeThreadId || '';
+      clearThreadDraft(threadKey);
+    }, [onSend, disabled, images, githubContext, composingNew, activeThreadId, clearThreadDraft]);
 
     const handleStopOrSubmit = useCallback(() => {
       if (isRunning && empty && images.length === 0 && onStop) {
@@ -434,6 +472,15 @@ Instructions:
       if (!el) return;
       updateEmpty();
 
+      // Save draft text
+      const { text } = extractContent(el);
+      const threadKey = composingNew ? 'new-thread' : activeThreadId || '';
+      if (text.trim()) {
+        setThreadDraft(threadKey, text);
+      } else {
+        clearThreadDraft(threadKey);
+      }
+
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0) return;
       const range = sel.getRangeAt(0);
@@ -457,7 +504,7 @@ Instructions:
 
         setPickerMode('categories');
       }
-    }, [showPicker, updateEmpty]);
+    }, [showPicker, updateEmpty, composingNew, activeThreadId, setThreadDraft, clearThreadDraft]);
 
     const handlePaste = useCallback(
       (e: React.ClipboardEvent) => {

--- a/apps/dashboard/src/stores/tasks-store.ts
+++ b/apps/dashboard/src/stores/tasks-store.ts
@@ -25,6 +25,7 @@ interface ThreadsState {
   searchQuery: string;
   threadScrollOffsets: Record<string, number>;
   threadSessionInfo: Record<string, ThreadSessionInfo>;
+  threadDrafts: Record<string, string>;
   setSearchQuery: (q: string) => void;
   fetchThreads: (projectId: string) => Promise<void>;
   setActiveThread: (threadId: string) => Promise<void>;
@@ -39,6 +40,9 @@ interface ThreadsState {
   setThreadSessionInfo: (threadId: string, info: ThreadSessionInfo) => void;
   deleteThread: (id: string) => Promise<void>;
   setThreadScrollOffset: (threadId: string, offset: number) => void;
+  setThreadDraft: (threadId: string, draft: string) => void;
+  getThreadDraft: (threadId: string) => string;
+  clearThreadDraft: (threadId: string) => void;
   reset: () => void;
 }
 
@@ -53,6 +57,7 @@ export const useThreadsStore = create<ThreadsState>((set, get) => ({
   searchQuery: '',
   threadScrollOffsets: {},
   threadSessionInfo: {},
+  threadDrafts: {},
 
   setSearchQuery: (q) => set({ searchQuery: q }),
 
@@ -162,6 +167,19 @@ export const useThreadsStore = create<ThreadsState>((set, get) => ({
       threadScrollOffsets: { ...state.threadScrollOffsets, [threadId]: offset },
     })),
 
+  setThreadDraft: (threadId, draft) =>
+    set((state) => ({
+      threadDrafts: { ...state.threadDrafts, [threadId]: draft },
+    })),
+
+  getThreadDraft: (threadId) => get().threadDrafts[threadId] || '',
+
+  clearThreadDraft: (threadId) =>
+    set((state) => {
+      const { [threadId]: _, ...remaining } = state.threadDrafts;
+      return { threadDrafts: remaining };
+    }),
+
   reset: () =>
     set({
       projectId: null,
@@ -174,5 +192,6 @@ export const useThreadsStore = create<ThreadsState>((set, get) => ({
       searchQuery: '',
       threadScrollOffsets: {},
       threadSessionInfo: {},
+      threadDrafts: {},
     }),
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,20 +10,20 @@
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^4.0.0"
 
-"@apex/api-e2e@file:/home/daytona/port-relay-feature-for-electron-desktop/apps/api-e2e":
+"@apex/api-e2e@file:/home/daytona/preserve-draft-text-when-switching-betwe/apps/api-e2e":
   version "0.0.1"
   resolved "file:apps/api-e2e"
   dependencies:
     dotenv "^16.4.5"
 
-"@apex/api@file:/home/daytona/port-relay-feature-for-electron-desktop/apps/api":
+"@apex/api@file:/home/daytona/preserve-draft-text-when-switching-betwe/apps/api":
   version "0.0.1"
   resolved "file:apps/api"
   dependencies:
     drizzle-orm "*"
     elysia "*"
 
-"@apex/cli@file:/home/daytona/port-relay-feature-for-electron-desktop/apps/cli":
+"@apex/cli@file:/home/daytona/preserve-draft-text-when-switching-betwe/apps/cli":
   version "0.1.0"
   resolved "file:apps/cli"
   dependencies:
@@ -45,28 +45,28 @@
     terminal-kit "^3.1.2"
     ws "^8.16.0"
 
-"@apex/dashboard-e2e@file:/home/daytona/port-relay-feature-for-electron-desktop/apps/dashboard-e2e":
+"@apex/dashboard-e2e@file:/home/daytona/preserve-draft-text-when-switching-betwe/apps/dashboard-e2e":
   version "0.0.1"
   resolved "file:apps/dashboard-e2e"
 
-"@apex/dashboard@file:/home/daytona/port-relay-feature-for-electron-desktop/apps/dashboard":
+"@apex/dashboard@file:/home/daytona/preserve-draft-text-when-switching-betwe/apps/dashboard":
   version "0.0.1"
   resolved "file:apps/dashboard"
 
-"@apex/desktop@file:/home/daytona/port-relay-feature-for-electron-desktop/apps/desktop":
+"@apex/desktop@file:/home/daytona/preserve-draft-text-when-switching-betwe/apps/desktop":
   version "0.0.1"
   resolved "file:apps/desktop"
   dependencies:
     electrobun latest
 
-"@apex/orchestrator@file:/home/daytona/port-relay-feature-for-electron-desktop/libs/orchestrator":
+"@apex/orchestrator@file:/home/daytona/preserve-draft-text-when-switching-betwe/libs/orchestrator":
   version "0.0.1"
   resolved "file:libs/orchestrator"
   dependencies:
     dockerode "^4.0.7"
     tslib "^2.3.0"
 
-"@apex/shared@file:/home/daytona/port-relay-feature-for-electron-desktop/libs/shared":
+"@apex/shared@file:/home/daytona/preserve-draft-text-when-switching-betwe/libs/shared":
   version "0.0.1"
   resolved "file:libs/shared"
   dependencies:
@@ -5910,7 +5910,7 @@ buildcheck@~0.0.6:
   resolved "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz"
   integrity sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==
 
-bun-types@*, bun-types@^1.3.11, bun-types@1.3.11, bun-types@latest:
+bun-types@*, bun-types@1.3.11, bun-types@latest:
   version "1.3.11"
   resolved "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz"
   integrity sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==
@@ -12452,7 +12452,7 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@*, ws@^8.12.0, ws@^8.13.0, ws@^8.16.0, ws@^8.20.0:
+ws@*, ws@^8.12.0, ws@^8.13.0, ws@^8.16.0, ws@^8.19.0:
   version "8.20.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==


### PR DESCRIPTION
Summary
Fixes #11 - Implements draft text preservation when switching between threads to prevent users from losing their work.

🎯 Problem Solved
Before: Draft text was lost when switching between threads, forcing users to retype their input
After: Draft text is automatically preserved per thread and restored when returning to any thread
🔧 Implementation Details
Enhanced Tasks Store (tasks-store.ts)
Added threadDrafts: Record<string, string> to store draft text per thread ID
Added thread draft management actions:
setThreadDraft(threadId: string, draft: string) - Save draft for specific thread
getThreadDraft(threadId: string) - Retrieve draft for specific thread
clearThreadDraft(threadId: string) - Clear draft for specific thread
Enhanced Prompt Input (prompt-input.tsx)
Auto-save: Draft text is saved on every input change using setThreadDraft()
Auto-restore: Draft is restored when component mounts or when switching threads
Smart clearing: Draft is only cleared on successful message send, not on navigation
Thread-aware: Uses thread ID as key, or 'new-thread' for composition mode
Empty handling: Doesn't save/restore empty or whitespace-only content
🚀 Key Features
✅ Thread-Specific Preservation: Each thread maintains its own independent draft
✅ New Thread Support: Composition mode ('new-thread') preserves drafts
✅ Smart Clearing: Drafts only clear on successful send or manual deletion
✅ Empty Draft Handling: Doesn't save/restore empty or whitespace-only content
✅ Seamless Integration: Works with existing features without breaking changes
✅ Performance Optimized: Minimal overhead with efficient draft storage

🎉 User Experience Impact
No more lost work when switching between threads during research/planning
Seamless workflow when juggling multiple conversations
Increased productivity by eliminating the need to retype content
Intuitive behavior that matches user expectations
📁 Files Changed
apps/dashboard/src/stores/tasks-store.ts - Added draft storage state and actions
apps/dashboard/src/components/agent/prompt-input.tsx - Implemented draft persistence logic
🧪 Testing
✅ Build verification passed
✅ TypeScript compilation successful
✅ Maintains backward compatibility
✅ Follows existing Zustand patterns and component architecture
🔄 Workflow
Type in prompt input → Draft is automatically saved
Switch to another thread → Draft is preserved in store
Return to original thread → Draft is automatically restored
Send message → Draft is cleared for that thread
Manual deletion → Draft is cleared for that thread
This implementation significantly improves the user experience by eliminating the frustration of lost draft text when switching between threads.

Summary
I have successfully analyzed and documented the solution for GitHub Issue #11. Here's what was accomplished:

✅ Issue Resolution Complete
The implementation was already completed and committed to the branch issue-11/preserve-draft-text-when-switching-between-threads with commit 2fd7fe4 titled "draft prompt keep fix".

🔍 Solution Analysis
Key Changes Made:

Enhanced tasks-store.ts:

Added threadDrafts: Record<string, string> for per-thread draft storage
Added setThreadDraft, getThreadDraft, and clearThreadDraft actions
Integrated draft management into the existing Zustand store
Enhanced prompt-input.tsx:

Added auto-save functionality on input changes
Added auto-restore functionality on component mount/thread changes
Smart draft clearing only on successful message send
Support for both regular threads and composition mode ('new-thread')
🎯 Problem Solved
Before: Users lost their draft text when switching between threads
After: Draft text is automatically preserved per thread and restored when returning
📋 Pull Request Ready
I've created a comprehensive pull request description above that you can use to create the PR manually on GitHub. The branch is already pushed and ready for review.

The solution follows the exact requirements from the GitHub issue:

✅ Draft text preserved when switching threads
✅ Draft restored when returning to original thread
✅ Draft only cleared on explicit user actions (delete/send)
✅ Seamless integration with existing codebase
✅ No breaking changes
The implementation significantly improves user experience by eliminating the frustration of lost work when switching between threads during multi-threaded conversations.