### PR TITLE
feat: decouple agent from client connectivity

### DIFF
--- a/apps/api/src/modules/agent/agent.ws.ts
+++ b/apps/api/src/modules/agent/agent.ws.ts
@@ -789,6 +789,10 @@ async function handleMessage(client: WsClient, message: unknown) {
 
   try {
     switch (type) {
+      case 'ping': {
+        client.wsSend(JSON.stringify({ type: 'pong' }));
+        return;
+      }
       case 'subscribe_project': {
         let project: Awaited<ReturnType<typeof projectsService.findById>>;
         try { project = await projectsService.findById(payload.projectId); } catch {

--- a/apps/dashboard/src/lib/reconnecting-ws.ts
+++ b/apps/dashboard/src/lib/reconnecting-ws.ts
@@ -11,11 +11,13 @@ export class ReconnectingWebSocket {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelay = 1000;
   private maxReconnectDelay = 30000;
-  private offlineReconnectDelay = 5000; // Longer delay when offline
-  private maxOfflineReconnectDelay = 60000; // Max 1 minute when offline
+  private offlineReconnectDelay = 5000;
+  private maxOfflineReconnectDelay = 60000;
   private destroyed = false;
   private pendingMessages: string[] = [];
   private networkUnsubscribe: (() => void) | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private pongTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(path: string) {
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -70,11 +72,16 @@ export class ReconnectingWebSocket {
         this.ws?.send(msg);
       }
       this.pendingMessages = [];
+      this.startHeartbeat();
     };
 
     this.ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
+        if (data.type === 'pong') {
+          this.clearPongTimer();
+          return;
+        }
         const typeHandlers = this.handlers.get(data.type);
         if (typeHandlers) {
           for (const handler of typeHandlers) handler(data);
@@ -87,6 +94,7 @@ export class ReconnectingWebSocket {
     };
 
     this.ws.onclose = () => {
+      this.stopHeartbeat();
       const networkStore = useNetworkStore.getState();
       this.notifyStatus('disconnected');
       networkStore.setSocketConnected(false);
@@ -131,6 +139,27 @@ export class ReconnectingWebSocket {
     }
   }
 
+  private startHeartbeat() {
+    this.stopHeartbeat();
+    this.pingTimer = setInterval(() => {
+      if (this.ws?.readyState !== WebSocket.OPEN) return;
+      this.ws.send(JSON.stringify({ type: 'ping' }));
+      this.pongTimer = setTimeout(() => {
+        // No pong received — connection is dead, force close to trigger reconnect
+        this.ws?.close();
+      }, 10_000);
+    }, 30_000);
+  }
+
+  private stopHeartbeat() {
+    if (this.pingTimer) { clearInterval(this.pingTimer); this.pingTimer = null; }
+    this.clearPongTimer();
+  }
+
+  private clearPongTimer() {
+    if (this.pongTimer) { clearTimeout(this.pongTimer); this.pongTimer = null; }
+  }
+
   private notifyStatus(status: 'connecting' | 'connected' | 'disconnected') {
     for (const handler of this.statusHandlers) handler(status);
   }
@@ -168,6 +197,7 @@ export class ReconnectingWebSocket {
   destroy() {
     this.destroyed = true;
     this.cancelReconnect();
+    this.stopHeartbeat();
     this.ws?.close();
     this.ws = null;
     this.handlers.clear();

--- a/libs/orchestrator/src/lib/bridge-script.ts
+++ b/libs/orchestrator/src/lib/bridge-script.ts
@@ -1829,7 +1829,14 @@ wss.on("connection", (ws) => {
     }
   });
 
+  var bridgePingTimer = setInterval(function() {
+    if (ws.readyState === 1) {
+      try { ws.ping(); } catch (e) {}
+    }
+  }, 30000);
+
   ws.on("close", () => {
+    clearInterval(bridgePingTimer);
     log("\\u{1F50C}", "Orchestrator disconnected — keeping " + activeThreads.size + " session(s) alive for recovery");
     state.ws = null;
   });

--- a/libs/orchestrator/src/lib/sandbox-manager.ts
+++ b/libs/orchestrator/src/lib/sandbox-manager.ts
@@ -247,6 +247,7 @@ export class SandboxManager extends EventEmitter {
   >();
   private startedAt = new Map<string, number>();
   private reconnectPromises = new Map<string, Promise<void>>();
+  private backgroundMonitors = new Map<string, ReturnType<typeof setInterval>>();
   private projectNames = new Map<string, string>();
   private projectIds = new Map<string, string>();
   private localDirs = new Map<string, string>();
@@ -636,20 +637,32 @@ export class SandboxManager extends EventEmitter {
       await this.ensureSandboxStarted(sandbox);
       log("sandbox started");
 
-      const [previewInfo] = await Promise.all([
-        sandbox.getPreviewLink(BRIDGE_PORT),
-        sandbox.fs
-          .uploadFile(
-            Buffer.from(getBridgeScript(BRIDGE_PORT, session.projectDir, undefined)),
-            `${session.bridgeDir}/bridge.cjs`,
-          )
-          .catch(() => {
-            /* best-effort */
-          }),
-      ]);
-      session.previewUrl = previewInfo.url;
-      session.previewToken = previewInfo.token ?? null;
-      log("got preview URL");
+      // Check if the bridge is already alive before deciding to re-upload.
+      // If it's healthy, skip the upload to avoid unnecessary bridge restarts
+      // and keep the running agent undisturbed.
+      const bridgeAlreadyAlive = await this.quickBridgeCheck(sandbox);
+
+      if (bridgeAlreadyAlive) {
+        const previewInfo = await sandbox.getPreviewLink(BRIDGE_PORT);
+        session.previewUrl = previewInfo.url;
+        session.previewToken = previewInfo.token ?? null;
+        log("bridge alive, skipping re-upload");
+      } else {
+        const [previewInfo] = await Promise.all([
+          sandbox.getPreviewLink(BRIDGE_PORT),
+          sandbox.fs
+            .uploadFile(
+              Buffer.from(getBridgeScript(BRIDGE_PORT, session.projectDir, undefined)),
+              `${session.bridgeDir}/bridge.cjs`,
+            )
+            .catch(() => {
+              /* best-effort */
+            }),
+        ]);
+        session.previewUrl = previewInfo.url;
+        session.previewToken = previewInfo.token ?? null;
+        log("bridge dead, re-uploaded bridge.cjs");
+      }
 
       await this.connectWithRetry(session);
       log("connected");
@@ -833,6 +846,44 @@ export class SandboxManager extends EventEmitter {
     return !!session?.ws && session.ws.readyState === WebSocket.OPEN;
   }
 
+  private static readonly BG_MONITOR_INTERVAL_MS = 15_000;
+  private static readonly BG_MONITOR_RETRY_DELAY_MS = 30_000;
+
+  /**
+   * Start a background monitor that proactively reconnects when the bridge
+   * WebSocket drops, rather than waiting for the next user prompt.
+   */
+  private startBackgroundMonitor(sandboxId: string): void {
+    this.stopBackgroundMonitor(sandboxId);
+    const interval = setInterval(async () => {
+      if (this.isBridgeConnected(sandboxId)) return;
+      const session = this.sessions.get(sandboxId);
+      if (!session || session.status === "completed" || session.status === "error") {
+        this.stopBackgroundMonitor(sandboxId);
+        return;
+      }
+      console.log(`[bg-monitor:${sandboxId.slice(0, 8)}] Bridge disconnected, initiating proactive reconnect`);
+      this.stopBackgroundMonitor(sandboxId);
+      const name = this.projectNames.get(sandboxId);
+      const localDir = this.localDirs.get(sandboxId);
+      try {
+        await this.reconnectSandbox(sandboxId, name, localDir);
+      } catch (err) {
+        console.error(`[bg-monitor:${sandboxId.slice(0, 8)}] Proactive reconnect failed:`, err instanceof Error ? err.message : err);
+        setTimeout(() => this.startBackgroundMonitor(sandboxId), SandboxManager.BG_MONITOR_RETRY_DELAY_MS);
+      }
+    }, SandboxManager.BG_MONITOR_INTERVAL_MS);
+    this.backgroundMonitors.set(sandboxId, interval);
+  }
+
+  private stopBackgroundMonitor(sandboxId: string): void {
+    const timer = this.backgroundMonitors.get(sandboxId);
+    if (timer) {
+      clearInterval(timer);
+      this.backgroundMonitors.delete(sandboxId);
+    }
+  }
+
   /** Request the bridge to replay journaled events for a thread from a given sequence number */
   requestReplay(sandboxId: string, threadId: string, afterSeq = 0): void {
     const session = this.sessions.get(sandboxId);
@@ -850,6 +901,7 @@ export class SandboxManager extends EventEmitter {
    * preserve the old opencode serve (which has stale env vars like proxy URLs).
    */
   forceDisconnect(sandboxId: string): void {
+    this.stopBackgroundMonitor(sandboxId);
     const session = this.sessions.get(sandboxId);
     if (session) {
       session.ws?.close();
@@ -940,6 +992,7 @@ export class SandboxManager extends EventEmitter {
    */
   async deleteSandbox(sandboxId: string): Promise<void> {
     const label = sandboxId.slice(0, 8);
+    this.stopBackgroundMonitor(sandboxId);
     this.sandboxCache.delete(sandboxId);
     this.startedAt.delete(sandboxId);
     this.projectNames.delete(sandboxId);
@@ -978,6 +1031,7 @@ export class SandboxManager extends EventEmitter {
    */
   async stopSandbox(sandboxId: string): Promise<void> {
     const label = sandboxId.slice(0, 8);
+    this.stopBackgroundMonitor(sandboxId);
     this.sandboxCache.delete(sandboxId);
     this.startedAt.delete(sandboxId);
     this.projectNames.delete(sandboxId);
@@ -2107,80 +2161,62 @@ export class SandboxManager extends EventEmitter {
   private async connectWithRetry(session: InternalSession): Promise<void> {
     const sid = session.sandboxId.slice(0, 8);
     const bridgeAlive = await this.quickBridgeCheck(session.sandbox);
-    const isFirstConnect = !session.bridgeSessionId;
+    const flaggedForRestart = this.forceFullRestart.delete(session.sandboxId);
     console.log(
-      `[bridge:${sid}] alive=${bridgeAlive} firstConnect=${isFirstConnect}`,
+      `[bridge:${sid}] alive=${bridgeAlive} forceRestart=${flaggedForRestart}`,
     );
 
-    if (isFirstConnect) {
-      const flaggedForRestart = this.forceFullRestart.delete(session.sandboxId);
-      const isDaytona = this.config.provider === "daytona";
-      const needsFullRestart = flaggedForRestart || isDaytona;
-      const preserveOpenCode = !needsFullRestart;
-      const restartMode = needsFullRestart
-        ? isDaytona && !flaggedForRestart ? 'full restart (daytona — fresh env vars)' : 'full restart (proxy recovery)'
-        : bridgeAlive ? 'soft restart' : 'restart (bridge dead, preserving opencode)';
-      console.log(
-        `[bridge:${sid}] ${restartMode} — first connect${preserveOpenCode ? ', preserving opencode serve' : ''}`,
-      );
-      await this.restartBridge(session, preserveOpenCode);
-      console.log(`[bridge:${sid}] ${restartMode} done, connecting WS`);
-      await this.connectToBridge(session);
-      console.log(`[bridge:${sid}] WS connected after ${restartMode}`);
-      return;
-    }
-
-    if (!bridgeAlive) {
-      console.log(
-        `[bridge:${sid}] restarting bridge (dead)`,
-      );
-      await this.restartBridge(session);
-      console.log(`[bridge:${sid}] bridge restarted, connecting WS`);
-      await this.connectToBridge(session);
-      console.log(`[bridge:${sid}] WS connected after restart`);
-      return;
-    }
-
-    let lastError: Error | null = null;
-    for (let attempt = 1; attempt <= 2; attempt++) {
-      try {
-        console.log(`[bridge:${sid}] WS connect attempt ${attempt}`);
-        await this.connectToBridge(session);
-        console.log(`[bridge:${sid}] WS connected on attempt ${attempt}`);
-        return;
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
-        console.log(
-          `[bridge:${sid}] WS attempt ${attempt} failed: ${lastError.message}`,
-        );
-        if (attempt < 2) {
-          try {
-            const previewInfo =
-              await session.sandbox.getPreviewLink(BRIDGE_PORT);
-            session.previewUrl = previewInfo.url;
-            session.previewToken = previewInfo.token ?? null;
-          } catch {
-            /* keep existing */
+    // If bridge is alive and no forced restart, just reconnect the WebSocket.
+    // The agent inside the sandbox is unaffected — we only lost the WS link.
+    if (bridgeAlive && !flaggedForRestart) {
+      let lastError: Error | null = null;
+      for (let attempt = 1; attempt <= 2; attempt++) {
+        try {
+          console.log(`[bridge:${sid}] WS connect attempt ${attempt} (bridge alive)`);
+          await this.connectToBridge(session);
+          console.log(`[bridge:${sid}] WS connected on attempt ${attempt}`);
+          return;
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          console.log(
+            `[bridge:${sid}] WS attempt ${attempt} failed: ${lastError.message}`,
+          );
+          if (attempt < 2) {
+            try {
+              const previewInfo =
+                await session.sandbox.getPreviewLink(BRIDGE_PORT);
+              session.previewUrl = previewInfo.url;
+              session.previewToken = previewInfo.token ?? null;
+            } catch {
+              /* keep existing */
+            }
+            await new Promise((r) => setTimeout(r, 500));
           }
-          await new Promise((r) => setTimeout(r, 500));
         }
       }
+      // WS connect failed despite bridge being alive — restart bridge only,
+      // always preserving the OpenCode agent process.
+      try {
+        console.log(`[bridge:${sid}] WS failed, restarting bridge (preserving opencode)`);
+        await this.restartBridge(session, /* preserveOpenCode */ true);
+        await this.connectToBridge(session);
+        console.log(`[bridge:${sid}] WS connected after bridge-only restart`);
+        return;
+      } catch (err) {
+        console.log(`[bridge:${sid}] final connect failed: ${err}`);
+      }
+      throw lastError || new Error("Failed to connect to bridge");
     }
 
-    try {
-      console.log(
-        `[bridge:${sid}] WS failed, restarting bridge as last resort`,
-      );
-      await this.restartBridge(session);
-      console.log(`[bridge:${sid}] bridge restarted, final WS connect`);
-      await this.connectToBridge(session);
-      console.log(`[bridge:${sid}] WS connected after restart`);
-      return;
-    } catch (err) {
-      console.log(`[bridge:${sid}] final connect failed: ${err}`);
-    }
-
-    throw lastError || new Error("Failed to connect to bridge");
+    // Bridge is dead or forced restart requested.
+    // Only kill OpenCode when explicitly flagged (user-initiated hard restart).
+    const preserveOpenCode = !flaggedForRestart;
+    const restartMode = flaggedForRestart ? 'full restart (forced)' : 'restart (bridge dead, preserving opencode)';
+    console.log(`[bridge:${sid}] ${restartMode}`);
+    await this.restartBridge(session, preserveOpenCode);
+    console.log(`[bridge:${sid}] ${restartMode} done, connecting WS`);
+    await this.connectToBridge(session);
+    console.log(`[bridge:${sid}] WS connected after ${restartMode}`);
   }
 
   /** Quick (non-blocking) check if the bridge HTTP server is responding inside the sandbox */
@@ -2904,11 +2940,28 @@ export class SandboxManager extends EventEmitter {
         reject(new Error("Connection timeout (5s)"));
       }, 5000);
 
+      const PING_INTERVAL_MS = 30_000;
+      const PONG_TIMEOUT_MS = 10_000;
+      let pingTimer: ReturnType<typeof setInterval> | null = null;
+      let pongReceived = true;
+
       ws.on("open", () => {
         clearTimeout(connectTimeout);
         session.status = "connecting";
         this.emit("status", session.sandboxId, "connecting");
+
+        pingTimer = setInterval(() => {
+          if (!pongReceived) {
+            console.log(`[bridge:${session.sandboxId.slice(0, 8)}] No pong received within ${PONG_TIMEOUT_MS / 1000}s, terminating WS`);
+            ws.terminate();
+            return;
+          }
+          pongReceived = false;
+          try { ws.ping(); } catch { /* socket may be closing */ }
+        }, PING_INTERVAL_MS);
       });
+
+      ws.on("pong", () => { pongReceived = true; });
 
       ws.on("message", (data) => {
         try {
@@ -2921,6 +2974,7 @@ export class SandboxManager extends EventEmitter {
             if ((msg as any).threads && typeof (msg as any).threads === "object") {
               this.emit("bridge_threads", session.sandboxId, (msg as any).threads);
             }
+            this.startBackgroundMonitor(session.sandboxId);
             resolve();
           } else if (msg.type === "agent_message") {
             this.handleAgentMessage(session, msg.data);
@@ -2977,11 +3031,11 @@ export class SandboxManager extends EventEmitter {
       });
 
       ws.on("close", (code) => {
+        if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
         if (session.status !== "completed" && session.status !== "error") {
-          session.status = "error";
-          session.error = `Disconnected (code: ${code})`;
-          session.endTime = Date.now();
-          this.emit("status", session.sandboxId, "error", session.error);
+          session.status = "disconnected";
+          session.error = `WS closed (code: ${code})`;
+          this.emit("status", session.sandboxId, "disconnected", session.error);
         }
       });
 

--- a/libs/orchestrator/src/lib/types.ts
+++ b/libs/orchestrator/src/lib/types.ts
@@ -388,6 +388,7 @@ export type SandboxSessionStatus =
   | 'running'
   | 'waiting_for_input'
   | 'completed'
+  | 'disconnected'
   | 'error';
 
 export interface SandboxSession {

--- a/workdocs/architecture-overview.md
+++ b/workdocs/architecture-overview.md
@@ -55,7 +55,21 @@ The prompt input stays editable while the agent is running. If the user submits 
 2. When the agent finishes (status transitions from `running`), the first queued prompt auto-sends
 3. Clicking Play on a queued prompt stops the current agent, then sends the queued prompt when the stop completes
 
-### Bridge Health Check
+### Bridge Connection Resilience
+
+The bridge connection is designed so that WebSocket disconnections (user inactivity, network blips, laptop sleep) never affect the running agent inside the sandbox. The OpenCode agent process is completely decoupled from client connectivity.
+
+**Keepalive**: Both the API-to-bridge WebSocket (`SandboxManager.connectToBridge`) and the bridge-side WebSocket server send RFC 6455 ping frames every 30s. If no pong is received before the next interval, the connection is terminated and the background monitor triggers a reconnect. The dashboard-to-API WebSocket uses application-level `{ type: "ping" }` / `{ type: "pong" }` messages (browser WebSockets don't support `ws.ping()`).
+
+**Background monitor**: A 15s interval (`startBackgroundMonitor`) runs for every connected sandbox. When `isBridgeConnected()` returns false, it proactively calls `reconnectSandbox()` — the user doesn't need to send a prompt to trigger reconnection.
+
+**Reconnection philosophy**: `connectWithRetry` checks if the bridge HTTP server is alive (`quickBridgeCheck`). If yes, it just reconnects the WebSocket without restarting anything. If the bridge is dead, it restarts the bridge process but **always preserves the OpenCode agent** (`preserveOpenCode = true`). OpenCode is only killed on explicit user-initiated actions (`forceFullRestart`). The `doReconnect` path also skips re-uploading `bridge.cjs` when the bridge is already healthy.
+
+**Session status**: A WebSocket close sets the session status to `disconnected` (not `error`), preventing error-handling cascades. The bridge keeps all active agent sessions alive when the orchestrator disconnects, and resumes polling for them when a new connection arrives (`recoverSessions`).
+
+**Event journal**: The bridge journals all agent events to disk per thread. On reconnect, the API can request a replay of missed events via `request_replay` with the last seen sequence number, ensuring no messages are lost during a disconnection gap.
+
+### Bridge Health Check (Active Agent Turn)
 A 10-second health check interval runs alongside every active agent execution:
 
 1. Every 10s, the gateway checks `manager.isBridgeConnected()` to verify the bridge WebSocket is alive

--- a/workdocs/multi-agent-bridge.md
+++ b/workdocs/multi-agent-bridge.md
@@ -64,6 +64,16 @@ Agents are defined in the `AgentType` enum (`libs/shared/src/lib/enums.ts`) and 
 | `apps/cli/internal/sandbox/bridge.go` | Go CLI `sendPrompt()` includes `agent` field |
 | `apps/cli/internal/sandbox/scripts.go` | `GenerateBridgeScript()` accepts `agentType` parameter |
 
+## Connection Resilience
+
+The bridge WebSocket connection between the API (`SandboxManager`) and the in-sandbox bridge is designed to be transparent to the running agent. Key mechanisms:
+
+- **Ping/pong keepalive**: Both sides send RFC 6455 ping frames every 30s; missing pong triggers socket termination and reconnect. The dashboard-to-API link uses app-level `{ type: "ping" }` / `{ type: "pong" }` JSON messages.
+- **Background monitor**: A 15s interval in `SandboxManager` detects disconnections and proactively calls `reconnectSandbox()` without waiting for user activity.
+- **Agent preservation**: Reconnection **never** kills the OpenCode process. `connectWithRetry` checks if the bridge is alive first and only reconnects the WebSocket. If the bridge died, it restarts the bridge Node process with `preserveOpenCode = true`. OpenCode is only killed on explicit `forceFullRestart`.
+- **Session recovery**: The bridge keeps active agent sessions alive when the orchestrator disconnects (`ws.on("close")` clears `state.ws` but doesn't stop polling). On new connection, `recoverSessions()` finds busy OpenCode sessions and resumes `pollSession()`.
+- **Event journal**: All agent events are journaled to disk per thread. The API can `request_replay` with `afterSeq` to backfill missed events after reconnection.
+
 ## Bridge Core Functions
 
 | Function | Role |


### PR DESCRIPTION
## Summary

- **Never kill OpenCode on reconnect**: `connectWithRetry` always preserves the agent process. Only explicit `forceFullRestart` (user-initiated) kills OpenCode. Previously, every Daytona reconnection killed both the bridge and the agent.
- **Skip unnecessary bridge restarts**: When the bridge HTTP server is still alive, just reconnect the WebSocket — no restart, no re-upload of `bridge.cjs`. Eliminates the most common cause of "agent loses context" on idle timeout.
- **Bidirectional ping/pong keepalive**: RFC 6455 ping frames every 30s on the API-to-bridge WebSocket (both directions) + app-level JSON ping/pong on the dashboard-to-API WebSocket. Prevents silent connection kills by intermediate proxies (Daytona preview proxy, cloud LBs).
- **Background bridge monitor**: 15s interval proactively reconnects when the bridge WebSocket drops, instead of waiting for the user to send a prompt.
- **Graceful disconnect status**: WS close sets session to `disconnected` (not `error`), preventing error-handling cascades on benign disconnects.

## Test plan

- [ ] Start a project, send a prompt, wait 2+ minutes idle, then send another prompt — agent should respond without "Bridge did not acknowledge" or context loss
- [ ] During an active agent run, simulate network blip (disconnect/reconnect WiFi) — agent should continue and output should resume
- [ ] Verify bridge reconnection logs show "bridge alive, skipping re-upload" on idle reconnects
- [ ] Test Daytona provider: confirm OpenCode is never killed on reconnect (check sandbox logs for absence of `pkill opencode`)
- [ ] Test local provider: same reconnection resilience
- [ ] Verify `forceDisconnect` (proxy recovery) still does a full restart when needed


Made with [Cursor](https://cursor.com)