### PR TITLE
fix: recover agent threads after laptop sleep instead of erroring

### DIFF
--- a/apps/api/src/modules/agent/agent.ws.ts
+++ b/apps/api/src/modules/agent/agent.ws.ts
@@ -491,6 +491,25 @@ async function executeAgainstSandbox(
     const prev = activeTimeouts.get(threadId);
     if (prev) clearTimeout(prev);
     const timer = setTimeout(async () => {
+      // After laptop sleep, the bridge may have reconnected in the
+      // background. Before erroring, check if the bridge is alive and
+      // the agent is still running — if so, recover via replay.
+      if (!manager.isBridgeConnected(project.sandboxId!)) {
+        try {
+          console.log(`[agent-ws] Timeout fired but bridge disconnected for ${threadId.slice(0, 8)}, attempting reconnect before error`);
+          const dirName = await resolveDirName(project);
+          await manager.reconnectSandbox(project.sandboxId!, dirName, project.localDir || undefined);
+        } catch { /* will fall through to retry/error below */ }
+      }
+      if (manager.isBridgeConnected(project.sandboxId!)) {
+        console.log(`[agent-ws] Bridge alive after timeout for ${threadId.slice(0, 8)}, requesting replay instead of erroring`);
+        const afterSeq = lastSeenSeq.get(threadId) || 0;
+        manager.requestReplay(project.sandboxId!, threadId, afterSeq);
+        startHealthCheck();
+        resetTimeout(AGENT_ACTIVITY_TIMEOUT_MS);
+        return;
+      }
+
       if (retryCount < 1) {
         retryCount++;
         emitToSubscribers(project.sandboxId!, 'agent_status', { threadId, status: 'retrying' });
@@ -560,12 +579,11 @@ async function executeAgainstSandbox(
             startHealthCheck();
             resetTimeout(AGENT_ACTIVITY_TIMEOUT_MS);
           } catch (err) {
-            console.error(`[agent-ws] Reconnect failed for ${threadId.slice(0, 8)} after grace:`, err);
+            // Don't immediately error — the background monitor may still
+            // reconnect. Clean up the handler silently and let
+            // reconcileAndReconnect handle recovery on the next subscribe.
+            console.warn(`[agent-ws] Reconnect failed for ${threadId.slice(0, 8)} after grace, deferring to next subscribe:`, err instanceof Error ? err.message : err);
             cleanupHandler();
-            await updateThreadStatusAndNotify(threadId, 'error');
-            emitToSubscribers(project.sandboxId!, 'agent_error', {
-              threadId, error: 'Lost connection to sandbox and could not reconnect.',
-            });
           }
         }, RECONNECT_GRACE_MS);
         activeTimeouts.set(threadId, graceTimer);
@@ -1538,6 +1556,24 @@ async function reconcileAndReconnect(
   client: WsClient,
 ) {
   try {
+    // Clean up stale active handlers from before sleep/disconnect.
+    // Their timeouts would fire with stale state; recovery will be
+    // handled by bridge_threads / running_sessions after reconnect.
+    const projectThreads = await threadsService.findByProject(projectId);
+    for (const t of projectThreads) {
+      const staleHandler = activeHandlers.get(t.id);
+      if (staleHandler) {
+        const manager = projectsService.getSandboxManager(_project.provider);
+        if (manager) manager.removeListener('message', staleHandler);
+        activeHandlers.delete(t.id);
+        const timer = activeTimeouts.get(t.id);
+        if (timer) { clearTimeout(timer); activeTimeouts.delete(t.id); }
+        const hc = activeHealthChecks.get(t.id);
+        if (hc) { clearInterval(hc); activeHealthChecks.delete(t.id); }
+        console.log(`[agent-ws] Cleaned up stale handler for thread ${t.id.slice(0, 8)} during reconnect`);
+      }
+    }
+
     const reconciled = await projectsService.reconcileSandboxStatus(projectId);
     if (reconciled.status === 'error') {
       emitTo(client, 'project_updated', reconciled);


### PR DESCRIPTION
## Summary

After laptop sleep, running agent threads would show "Error connecting to bridge" or "Agent stopped responding after 90 seconds" even though the agent was still alive in the sandbox. This happened because:

1. Stale timers from before sleep fire immediately on wake
2. The bridge WebSocket died during sleep, so health checks fail
3. Activity timeouts fire as expired, marking the thread as error

Three changes fix this:

- **Activity timeout recovery**: Before erroring, attempts to reconnect the bridge and request replay. If the bridge is reachable (common — it just needs a new WebSocket), recovers the thread with replay instead of failing.
- **Grace timer deferral**: On reconnect failure, silently cleans up the handler instead of marking the thread as error. Recovery is deferred to `reconcileAndReconnect` on the next `subscribe_project`.
- **Stale handler cleanup**: `reconcileAndReconnect` now cleans up all stale active handlers and their timers before reconnecting, preventing ghost timeouts from the pre-sleep session.

## Test plan

- [ ] Start an agent run, close laptop lid for 2+ minutes, reopen — thread should recover (not error)
- [ ] Start an agent run, disconnect WiFi for 60s, reconnect — thread should recover
- [ ] Verify normal timeouts still work (kill the bridge process manually — should eventually error after retry)
- [ ] Verify `reconcileAndReconnect` properly restores running threads after sleep


Made with [Cursor](https://cursor.com)